### PR TITLE
Some fixes to jQuery.xarea

### DIFF
--- a/jquery.xarea.js
+++ b/jquery.xarea.js
@@ -34,6 +34,7 @@
         $mimic.css('min-height', $textarea.outerHeight());
         $mimic.css('padding', $textarea.css('padding'));
         $mimic.css('padding-bottom', '0.7em');
+        $mimic.css('border', $textarea.css('border'));
         $mimic.css('width', '100%');
         $mimic.css('visibility', 'hidden'); // not display:none as we want the layouting
         

--- a/jquery.xarea.js
+++ b/jquery.xarea.js
@@ -15,7 +15,7 @@
                 var autosize = setupAutosize(markup);
                 autosize();
             });
-        },
+        }
     });
     
     var setupMarkup = function($textarea) {
@@ -28,7 +28,7 @@
             fontFamily:     $textarea.css('font-family'),
             fontSize:       $textarea.css('font-size'),
             fontWeight:     $textarea.css('font-weight'),
-            lineHeight:     $textarea.css('line-height'),
+            lineHeight:     $textarea.css('line-height')
         });
         setCss($mimic, 'box-sizing', 'border-box');
         $mimic.css('min-height', $textarea.outerHeight());
@@ -43,7 +43,7 @@
             width:      '100%',
             height:     '100%',
             overflow:   'hidden',
-            position:   'absolute',
+            position:   'absolute'
         });
         
         // replace it with container

--- a/jquery.xarea.js
+++ b/jquery.xarea.js
@@ -82,9 +82,9 @@
    };
    
    var htmlEscape = function(str) {
-       return str.replace(/</g, '&lt;')
+       return str.replace(/&/g, '&amp;')
+                 .replace(/</g, '&lt;')
                  .replace(/>/g, '&gt;')
-                 .replace(/&/g, '&amp;')
                  .replace(/\n$/, '<br/>&nbsp;')
                  .replace(/\n/g, '<br/>')
                  .replace(/ {2,}/g, function(spaces) {


### PR DESCRIPTION
Hi Karol,

Thanks for jQuery.xarea. I made some changes to it though. Here are the reasons why:
1. The removal of trailing comma's was necessary for the Google Closure compiler (and probably for IE too in uncompiled state).
2. Adding the border css properties to $mimic gives truer dimensions.
3. htmlEscape gave us double escaped stuff in $mimic such as &amp;amp;lt; - rendering the $mimic box larger than the original textarea.
