### PR TITLE
Adding margin fix for Bootstrap forms

### DIFF
--- a/jquery.xarea.js
+++ b/jquery.xarea.js
@@ -32,6 +32,7 @@
         });
         setCss($mimic, 'box-sizing', 'border-box');
         $mimic.css('min-height', $textarea.outerHeight());
+        $mimic.css('margin', $textarea.css('margin'));
         $mimic.css('padding', $textarea.css('padding'));
         $mimic.css('padding-bottom', '0.7em');
         $mimic.css('border', $textarea.css('border'));


### PR DESCRIPTION
Hi,

Thanks for this plugin, simple and effective :)

I'm using it in a site that's styled with Bootstrap, which puts margins on textarea elements in forms.

So I added the margin property to those cloned onto the $mimic div, which fixes layout issues.

Cheers,
Jed.
