### PR TITLE
Ensure there is a baseline

### DIFF
--- a/jquery.xarea.js
+++ b/jquery.xarea.js
@@ -64,7 +64,7 @@
         markup.$textarea.css('resize', 'none'); // no manual sizing
         
         var autosize = function() {
-            var text = htmlEscape(markup.$textarea.val());
+            var text = htmlEscape(markup.$textarea.val()) + '&#8203;';
             markup.$mimic.html(text);
         };
         markup.$textarea.on('change keydown keyup', autosize);


### PR DESCRIPTION
The change adds a zero width space to the invisible div. 
This ensures we always have a baseline for vertical alignment purposes such as align-items: start (when used as an item, or child of an item, in flex and grid).